### PR TITLE
Change elisp to Emacs Lisp.

### DIFF
--- a/femto.tex
+++ b/femto.tex
@@ -91,7 +91,7 @@ the editor with an immediate result check.
 
 For historical reasons, the reference GNU
 Emacs implementation uses a specialised version of
-lisp known as elisp.  However, the elisp
+lisp known as Emacs Lisp.  However, the Emacs Lisp
 dialect is not standard lisp, being used
 only by the GNU Emacs editor and its
 derivatives.


### PR DESCRIPTION
The official name is Emacs Lisp.

Historical tidbit: There were actually two other lisps going by the name elisp.  One was the extension language used in the  CCA Emacs editor, and the other was a standalone lisp by Rutgers University.
